### PR TITLE
fix(crypto): pubkey, signed data and PAHandler

### DIFF
--- a/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/PassiveAuthenticationHandler.swift
+++ b/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/PassiveAuthenticationHandler.swift
@@ -55,7 +55,7 @@ internal final class PassiveAuthenticationHandler {
                 throw NFCPassportReaderError.PassiveAuthenticationFailed("Data group hash not found in SOD")
             }
             
-            let computedHash = try HashAlgorithm.hash([UInt8](dataGroup.data.encodedBytes), with: sod.signedData.digestAlgorithm)
+            let computedHash = try HashAlgorithm.hash([UInt8](dataGroup.data.encodedBytes), with: sod.signedData.digestAlgorithm ?? .SHA1 )
             
             if computedHash != currentSodHash {
                 throw NFCPassportReaderError.PassiveAuthenticationFailed("\(String(describing: dataGroup.identifier)) hash not match")

--- a/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/SignedData.swift
+++ b/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/SignedData.swift
@@ -77,7 +77,7 @@ internal final class SignedData {
     private var data: ASN1NodeCollection
     
     /// The hash algorithm used for signing.
-    private(set) var digestAlgorithm: HashAlgorithm!
+    private(set) var digestAlgorithm: HashAlgorithm?
     
     /// A dictionary representing encapsulated content information,
     /// where the key is the ``DGTag`` and the value is the data group hash.

--- a/Sources/NFCPassportReader/Security/SubjectPublicKeyInfo.swift
+++ b/Sources/NFCPassportReader/Security/SubjectPublicKeyInfo.swift
@@ -58,7 +58,7 @@ internal final class SubjectPublicKeyInfo {
                     throw NFCPassportReaderError.UnexpectedResponseStructure
                 }
                 
-                bytes = [UInt8](keyBytes.dropFirst())
+                bytes = [UInt8](keyBytes)
             }
         }
         


### PR DESCRIPTION
- Fixed a bug that was causing a fatal error during PassiveAuthentication:
   - digest alg is now nullable in SignedData
   - if digest alg is nil then use try to use SHA1
- Fixed an issue during the SubjectPublicKeyInfo parsing