### PR TITLE
patch(models): public exposed data

### DIFF
--- a/Sources/NFCPassportReader/Models/DocumentDetails.swift
+++ b/Sources/NFCPassportReader/Models/DocumentDetails.swift
@@ -17,7 +17,17 @@ public struct DocumentDetails {
     private var details: [ASN1Tag: String] = [:]
     
     public var iussingAuthority: String? { details[0x5F19] }
-    public var dateOfIssue: String? { details[0x5F26] }
+    
+    public var dateOfIssue: String? {
+        if let date = details[0x5F26] {
+            let strategy = Date.ParseStrategy(
+                format: "\(year: .padded(4))\(month: .twoDigits)\(day: .twoDigits)",
+                timeZone: TimeZone(identifier: "UTC")!
+            )
+            return try? Date(date, strategy: strategy).formatted(date: .abbreviated, time: .omitted)
+        } else { return details[0x5F26] }
+    }
+    
     public var otherPersonDetails: String? { details[0xA0] }
     public var endorsementsOrObservations: String? { details[0x5F1B] }
     public var taxOrExitRequirements: String? { details[0x5F1C] }

--- a/Sources/NFCPassportReader/Models/MRZ.swift
+++ b/Sources/NFCPassportReader/Models/MRZ.swift
@@ -28,17 +28,17 @@ public struct MRZ {
     private var bytes: [UInt8]
     private var type: TDType
     
-    var code: String? { String(bytes: bytes, encoding: .utf8) }
+    public var code: String? { String(bytes: bytes, encoding: .utf8) }
     
-    var documentCode: String? {
+    public var documentCode: String? {
         String(bytes: bytes[0..<2], encoding:.utf8)
     }
     
-    var issuingState: String? {
+    public var issuingState: String? {
         String(bytes: bytes[2..<5], encoding:.utf8)
     }
     
-    var holderName: String? {
+    public var holderName: String? {
         switch self.type {
         case .TD1: String(bytes: bytes[60...], encoding:.utf8)
         case .TD2: String(bytes: bytes[5..<36], encoding:.utf8)
@@ -46,7 +46,7 @@ public struct MRZ {
         }
     }
     
-    var documentNumber: String? {
+    public var documentNumber: String? {
         switch self.type {
         case .TD1: String(bytes: bytes[5..<14], encoding:.utf8)
         case .TD2: String(bytes: bytes[36..<45], encoding:.utf8)
@@ -54,7 +54,7 @@ public struct MRZ {
         }
     }
     
-    var documentNumberCheckDigit: String? {
+    public var documentNumberCheckDigit: String? {
         switch type {
         case .TD1: String(bytes: bytes[14..<15], encoding:.utf8)
         case .TD2: String(bytes: bytes[45..<46], encoding:.utf8)
@@ -62,7 +62,7 @@ public struct MRZ {
         }
     }
     
-    var nationality: String? {
+    public var nationality: String? {
         switch self.type {
         case .TD1: String(bytes: bytes[45..<48], encoding:.utf8)
         case .TD2: String(bytes: bytes[46..<49], encoding:.utf8)
@@ -70,7 +70,7 @@ public struct MRZ {
         }
     }
     
-    var dateOfBirth: String? {
+    public var dateOfBirth: String? {
         switch self.type {
         case .TD1: String(bytes: bytes[30..<36], encoding:.utf8)
         case .TD2: String(bytes: bytes[49..<55], encoding:.utf8)
@@ -78,7 +78,7 @@ public struct MRZ {
         }
     }
     
-    var dateOfBirthCheckDigit: String? {
+    public var dateOfBirthCheckDigit: String? {
         switch self.type {
         case .TD1: String(bytes: [bytes[36]], encoding:.utf8)
         case .TD2: String(bytes: [bytes[55]], encoding:.utf8)
@@ -86,7 +86,7 @@ public struct MRZ {
         }
     }
     
-    var sex: String? {
+    public var sex: String? {
         switch self.type {
         case .TD1: String(bytes: [bytes[37]], encoding:.utf8)
         case .TD2: String(bytes: [bytes[56]], encoding:.utf8)
@@ -94,7 +94,7 @@ public struct MRZ {
         }
     }
     
-    var dateOfExpiry: String? {
+    public var dateOfExpiry: String? {
         switch self.type {
         case .TD1: String(bytes: bytes[38..<44], encoding:.utf8)
         case .TD2: String(bytes: bytes[57..<63], encoding:.utf8)
@@ -102,7 +102,7 @@ public struct MRZ {
         }
     }
     
-    var dateOfExpiryCheckDigit: String? {
+    public var dateOfExpiryCheckDigit: String? {
         switch self.type {
         case .TD1: String(bytes: [bytes[44]], encoding:.utf8)
         case .TD2: String(bytes: [bytes[63]], encoding:.utf8)
@@ -110,7 +110,7 @@ public struct MRZ {
         }
     }
     
-    var optionalData: String? {
+    public var optionalData: String? {
         switch self.type {
         case .TD1:
             (String(bytes: bytes[15..<30], encoding:.utf8) ?? "") +
@@ -120,13 +120,13 @@ public struct MRZ {
         }
     }
     
-    var checkDigit: String? {
+    public var checkDigit: String? {
         if self.type == .TD3 {
             String(bytes: [bytes[86]], encoding:.utf8)
         } else { nil }
     }
     
-    var compositeCheckDigit: String? {
+    public var compositeCheckDigit: String? {
         switch self.type {
         case .TD1: nil
         case .TD2: String(bytes: bytes[71..<72], encoding:.utf8)

--- a/Sources/NFCPassportReader/Models/PersonalDetails.swift
+++ b/Sources/NFCPassportReader/Models/PersonalDetails.swift
@@ -16,11 +16,44 @@ public struct PersonalDetails {
 
     private var details: [ASN1Tag: String] = [:]
     
-    public var fullName: String? { details[0x5F0E] }
+    public var fullName: String? {
+        if let components = details[0x5F0E]?.components(separatedBy: "<<") {
+            let surname = components[0].components(separatedBy: "<").joined(separator: " ")
+            let name = components[1].components(separatedBy: "<").joined(separator: " ")
+            return [surname, name].joined(separator: " ")
+        } else { return details[0x5F0E] }
+    }
+    
     public var personalNumber: String? { details[0x5F10] }
-    public var dateOfBirth: String? { details[0x5F2B] }
-    public var placeOfBirth: String? { details[0x5F11] }
-    public var address: String? { details[0x5F42] }
+    
+    public var dateOfBirth: String? {
+        if let date = details[0x5F2B] {
+            let strategy = Date.ParseStrategy(
+                format: "\(year: .padded(4))\(month: .twoDigits)\(day: .twoDigits)",
+                timeZone: TimeZone(identifier: "UTC")!
+            )
+            return try? Date(date, strategy: strategy).description
+        } else { return nil }
+    }
+    
+    public var placeOfBirth: String? {
+        if let components = details[0x5F11]?.components(separatedBy: "<") {
+            let city = components[0]
+            let province = "\(components[1])"
+            return "\(city) (\(province))"
+        } else { return details[0x5F11] }
+        
+    }
+    
+    public var address: String? {
+        if let components = details[0x5F42]?.components(separatedBy: "<") {
+            let address = components[0]
+            let city = components[1]
+            let province = components[2]
+            return "\(address) \(city) (\(province))"
+        } else { return details[0x5F42] }
+    }
+    
     public var telephone: String? { details[0x5F12] }
     public var profession: String? { details[0x5F13] }
     public var title: String? { details[0x5F14] }

--- a/Sources/NFCPassportReader/Models/PersonalDetails.swift
+++ b/Sources/NFCPassportReader/Models/PersonalDetails.swift
@@ -24,6 +24,20 @@ public struct PersonalDetails {
         } else { return details[0x5F0E] }
     }
     
+    internal var surname: String? {
+        if let components = details[0x5F0E]?.components(separatedBy: "<<") {
+            let surname = components[0].components(separatedBy: "<").joined(separator: " ")
+            return surname
+        } else { return details[0x5F0E] }
+    }
+    
+    internal var name: String? {
+        if let components = details[0x5F0E]?.components(separatedBy: "<<") {
+            let name = components[1].components(separatedBy: "<").joined(separator: " ")
+            return name
+        } else { return details[0x5F0E] }
+    }
+    
     public var personalNumber: String? { details[0x5F10] }
     
     public var dateOfBirth: String? {
@@ -32,8 +46,8 @@ public struct PersonalDetails {
                 format: "\(year: .padded(4))\(month: .twoDigits)\(day: .twoDigits)",
                 timeZone: TimeZone(identifier: "UTC")!
             )
-            return try? Date(date, strategy: strategy).description
-        } else { return nil }
+            return try? Date(date, strategy: strategy).formatted(date: .abbreviated, time: .omitted)
+        } else { return details[0x5F2B] }
     }
     
     public var placeOfBirth: String? {

--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -49,13 +49,13 @@ public struct NFCPassportModel {
     }
     
     public var firstName: String {
-        personalDetails?.fullName?.components(separatedBy: "<<")[0] ??
-        travelDocument?.mrz.holderName?.components(separatedBy: "<<")[0] ?? "Unkown"
+        personalDetails?.fullName?.components(separatedBy: "<<")[1] ??
+        travelDocument?.mrz.holderName?.components(separatedBy: "<<")[1] ?? "Unkown"
     }
     
     public var lastName: String {
-        personalDetails?.fullName?.components(separatedBy: "<<")[1] ??
-        travelDocument?.mrz.holderName?.components(separatedBy: "<<")[1] ?? "Unkown"
+        personalDetails?.fullName?.components(separatedBy: "<<")[0] ??
+        travelDocument?.mrz.holderName?.components(separatedBy: "<<")[0] ?? "Unkown"
     }
     
     public var holderPicture: UIImage? {

--- a/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/X509CertificateDetails.swift
+++ b/Sources/NFCPassportReader/Security/IC/ICDataAuthentication/X509CertificateDetails.swift
@@ -12,31 +12,31 @@ import OpenSSL
 ///
 /// - SeeAlso: ``X509Certificate``
 
-internal struct X509CertificateDetails {
+public struct X509CertificateDetails {
     
     /// The fingerprint of the certificate.
-    private(set) var fingerprint: String?
+    public private(set) var fingerprint: String?
     
     /// The issuer of the certificate.
-    private(set) var iusser: CertificateEntity?
+    public private(set) var iusser: CertificateEntity?
     
     /// The subject (soggetto) of the certificate.
-    private(set) var subject: CertificateEntity?
+    public private(set) var subject: CertificateEntity?
     
     /// The serial number of the certificate.
-    private(set) var serialNumber: String?
+    public private(set) var serialNumber: String?
     
     /// The name of the signature algorithm used in the certificate.
-    private(set) var signatureAlgorithmName: String?
+    public private(set) var signatureAlgorithmName: String?
     
     /// The name of the public key algorithm used in the certificate.
-    private(set) var publicKeyAlgorithmName: String?
+    public private(set) var publicKeyAlgorithmName: String?
     
     /// The date of issue (validity start) of the certificate.
-    private(set) var dateOfIssue: String?
+    public private(set) var dateOfIssue: String?
     
     /// The date of expiry (validity end) of the certificate.
-    private(set) var dateOfExpiry: String?
+    public private(set) var dateOfExpiry: String?
     
     /// Initialize the ``X509CertificateDetails`` structure with an OpenSSL `X509` certificate.
     ///
@@ -135,23 +135,23 @@ private extension X509CertificateDetails {
 
 /// ``CertificateEntity`` is a structure representing the entity (issuer or subject) of an X.509 certificate.
 
-internal extension X509CertificateDetails {
+public extension X509CertificateDetails {
     struct CertificateEntity {
         
         /// The country associated with the entity.
-        private(set) var country: String?
+        public private(set) var country: String?
         
         /// The organization associated with the entity.
-        private(set) var organization: String?
+        public private(set) var organization: String?
         
         /// The organizational unit associated with the entity.
-        private(set) var organizationUnit: String?
+        public private(set) var organizationUnit: String?
         
         /// The common name associated with the entity.
-        private(set) var commonName: String?
+        public private(set) var commonName: String?
         
         /// The serial number associated with the entity.
-        private(set) var serialNumber: String?
+        public private(set) var serialNumber: String?
         
         /// Initialize the ``CertificateEntity`` with a description string.
         ///


### PR DESCRIPTION
NFCPassportModel now exports more info also about security protocols, data groups and the X509 certificate stored within the SOD.

In addition, the following changes have been made:
- Dates are now formatted
- Filler chars have been removed from the exported strings
- Fixed exported name and surname that was switched
- Fixed MRZ struct internal properties (now public and exported)
- Properties within X509CertificateDetails struct are now exported